### PR TITLE
fix: complete forgot password flow with code entry and Cognito email template

### DIFF
--- a/apps/infrastructure/src/vinventure-lambda-stack.ts
+++ b/apps/infrastructure/src/vinventure-lambda-stack.ts
@@ -121,6 +121,11 @@ export class VinventureLambdaStack extends cdk.Stack {
         requireDigits: true,
         requireSymbols: false,
       },
+      userVerification: {
+        emailSubject: 'Verify your VinVenture account',
+        emailBody: 'Welcome to VinVenture! Your verification code is {####}',
+        emailStyle: cognito.VerificationEmailStyle.CODE,
+      },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       removalPolicy: isProduction 
         ? cdk.RemovalPolicy.RETAIN 

--- a/apps/web/components/auth/ForgotPasswordForm.tsx
+++ b/apps/web/components/auth/ForgotPasswordForm.tsx
@@ -9,13 +9,18 @@ interface ForgotPasswordFormProps {
 
 export default function ForgotPasswordForm({ onBack }: ForgotPasswordFormProps) {
   const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  
-  const { resetPassword } = useAuth();
+  const [codeSent, setCodeSent] = useState(false);
+  const [resetComplete, setResetComplete] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const { resetPassword, confirmResetPassword } = useAuth();
+
+  const handleSendCode = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     setMessage('');
@@ -23,69 +28,194 @@ export default function ForgotPasswordForm({ onBack }: ForgotPasswordFormProps) 
 
     try {
       await resetPassword(email);
+      setCodeSent(true);
       setMessage('Check your email for your password reset code');
     } catch (err: any) {
-      setError(err.message || 'Failed to send reset email');
+      setError(err.message || 'Failed to send reset code');
     } finally {
       setLoading(false);
     }
   };
+
+  const handleResetPassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      await confirmResetPassword(email, code, newPassword);
+      setResetComplete(true);
+      setMessage('Password reset successfully! You can now sign in.');
+    } catch (err: any) {
+      setError(err.message || 'Failed to reset password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (resetComplete) {
+    return (
+      <div className="w-full max-w-md mx-auto text-center">
+        <div className="mx-auto w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mb-4">
+          <span className="text-green-600 text-xl">&#10003;</span>
+        </div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Password Reset</h2>
+        <p className="text-green-600 mb-6">{message}</p>
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="text-purple-600 hover:text-purple-500 font-medium"
+          >
+            Back to Sign In
+          </button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="w-full max-w-md mx-auto">
       <div className="text-center mb-6">
         <h2 className="text-2xl font-bold text-gray-900">Reset Password</h2>
         <p className="mt-2 text-sm text-gray-600">
-          Enter your email address and we&apos;ll send you a code to reset your password.
+          {codeSent
+            ? 'Enter the code from your email and choose a new password.'
+            : 'Enter your email address and we&apos;ll send you a code to reset your password.'}
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-            Email Address
-          </label>
-          <input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-            placeholder="Enter your email"
-          />
-        </div>
-
-        {error && (
-          <div className="text-red-600 text-sm text-center bg-red-50 p-3 rounded-md">
-            {error}
+      {!codeSent ? (
+        <form onSubmit={handleSendCode} className="space-y-6">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Enter your email"
+            />
           </div>
-        )}
 
-        {message && (
-          <div className="text-green-600 text-sm text-center bg-green-50 p-3 rounded-md">
-            {message}
+          {error && (
+            <div className="text-red-600 text-sm text-center bg-red-50 p-3 rounded-md">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Sending...' : 'Send Reset Code'}
+          </button>
+
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="w-full text-sm text-purple-600 hover:text-purple-500"
+            >
+              Back to Sign In
+            </button>
+          )}
+        </form>
+      ) : (
+        <form onSubmit={handleResetPassword} className="space-y-4">
+          <div>
+            <label htmlFor="code" className="block text-sm font-medium text-gray-700 mb-2">
+              Reset Code
+            </label>
+            <input
+              id="code"
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              required
+              maxLength={6}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500 text-center text-lg tracking-widest"
+              placeholder="Enter 6-digit code"
+            />
           </div>
-        )}
 
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {loading ? 'Sending...' : 'Send Reset Code'}
-        </button>
+          <div>
+            <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700 mb-2">
+              New Password
+            </label>
+            <input
+              id="newPassword"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+              minLength={8}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Enter new password"
+            />
+          </div>
 
-        {onBack && (
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-2">
+              Confirm New Password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              minLength={8}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Confirm new password"
+            />
+          </div>
+
+          {error && (
+            <div className="text-red-600 text-sm text-center bg-red-50 p-3 rounded-md">
+              {error}
+            </div>
+          )}
+
+          {message && (
+            <div className="text-green-600 text-sm text-center bg-green-50 p-3 rounded-md">
+              {message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !code.trim() || !newPassword || !confirmPassword}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Resetting...' : 'Reset Password'}
+          </button>
+
           <button
             type="button"
-            onClick={onBack}
+            onClick={() => { setCodeSent(false); setError(''); setMessage(''); }}
             className="w-full text-sm text-purple-600 hover:text-purple-500"
           >
-            Back to Sign In
+            Resend Code
           </button>
-        )}
-      </form>
+        </form>
+      )}
     </div>
   );
 }

--- a/apps/web/components/auth/ForgotPasswordForm.tsx
+++ b/apps/web/components/auth/ForgotPasswordForm.tsx
@@ -23,7 +23,7 @@ export default function ForgotPasswordForm({ onBack }: ForgotPasswordFormProps) 
 
     try {
       await resetPassword(email);
-      setMessage('Check your email for password reset instructions');
+      setMessage('Check your email for your password reset code');
     } catch (err: any) {
       setError(err.message || 'Failed to send reset email');
     } finally {
@@ -36,7 +36,7 @@ export default function ForgotPasswordForm({ onBack }: ForgotPasswordFormProps) 
       <div className="text-center mb-6">
         <h2 className="text-2xl font-bold text-gray-900">Reset Password</h2>
         <p className="mt-2 text-sm text-gray-600">
-          Enter your email address and we&apos;ll send you a link to reset your password.
+          Enter your email address and we&apos;ll send you a code to reset your password.
         </p>
       </div>
 
@@ -73,7 +73,7 @@ export default function ForgotPasswordForm({ onBack }: ForgotPasswordFormProps) 
           disabled={loading}
           className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {loading ? 'Sending...' : 'Send Reset Link'}
+          {loading ? 'Sending...' : 'Send Reset Code'}
         </button>
 
         {onBack && (

--- a/apps/web/contexts/AuthContext.tsx
+++ b/apps/web/contexts/AuthContext.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
   confirmEmail: (email: string, code: string) => Promise<void>;
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
+  confirmResetPassword: (email: string, code: string, newPassword: string) => Promise<void>;
   refreshSession: () => Promise<void>;
 }
 
@@ -31,6 +32,7 @@ export function useAuth() {
         confirmEmail: async () => { throw new Error('Cannot confirm email during SSR'); },
         signOut: async () => { throw new Error('Cannot sign out during SSR'); },
         resetPassword: async () => { throw new Error('Cannot reset password during SSR'); },
+        confirmResetPassword: async () => { throw new Error('Cannot confirm reset during SSR'); },
         refreshSession: async () => { throw new Error('Cannot refresh session during SSR'); },
       } as AuthContextType;
     }
@@ -136,6 +138,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return CognitoAuthService.forgotPassword(email);
   };
 
+  const confirmResetPassword = async (email: string, code: string, newPassword: string): Promise<void> => {
+    return CognitoAuthService.confirmForgotPassword(email, code, newPassword);
+  };
+
   const refreshSession = async (): Promise<void> => {
     if (typeof window === 'undefined') {
       throw new Error('Cannot refresh session during server-side rendering');
@@ -173,6 +179,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     confirmEmail,
     signOut,
     resetPassword,
+    confirmResetPassword,
     refreshSession,
   };
 


### PR DESCRIPTION
## Summary
- Add two-step forgot password flow: enter email → enter code + new password
- Expose `confirmResetPassword` in auth context (was missing from UI)
- Fix button text from "Send Reset Link" to "Send Reset Code" (Cognito sends codes, not links)
- Customize Cognito verification email template in CDK stack

## Test plan
- [ ] Click "Forgot Password" → enter email → receive code
- [ ] Enter code + new password → password resets successfully
- [ ] "Back to Sign In" works after reset
- [ ] "Resend Code" sends a new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)