### PR TITLE
v0.1.0.0 fix: break circular dependency in CDK stack

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -48,7 +48,7 @@ jobs:
           pnpm audit --audit-level moderate || true
 
       - name: OSV Scanner
-        uses: google/osv-scanner-action@v1
+        uses: google/osv-scanner-action/osv-scanner@v2
         with:
           scan-args: |-
             -r

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -48,7 +48,7 @@ jobs:
           pnpm audit --audit-level moderate || true
 
       - name: OSV Scanner
-        uses: google/osv-scanner-action/osv-scanner@v2
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
         with:
           scan-args: |-
             -r

--- a/apps/infrastructure/src/vinventure-lambda-stack.ts
+++ b/apps/infrastructure/src/vinventure-lambda-stack.ts
@@ -165,7 +165,9 @@ export class VinventureLambdaStack extends cdk.Stack {
       ],
     });
 
-    // Cognito User Pool Client -- callback URLs include CloudFront distribution
+    // Cognito User Pool Client
+    // Note: CloudFront callback URL must be added post-deploy to avoid circular dependency
+    // (distribution -> api -> lambda -> userPoolClient -> distribution)
     const userPoolClient = new cognito.UserPoolClient(this, 'VinventureUserPoolClient', {
       userPool,
       userPoolClientName: 'VinVenture Web Client',
@@ -185,11 +187,9 @@ export class VinventureLambdaStack extends cdk.Stack {
         ],
         callbackUrls: [
           'http://localhost:3000/auth/callback',
-          `https://${distribution.domainName}/auth/callback`,
         ],
         logoutUrls: [
           'http://localhost:3000/',
-          `https://${distribution.domainName}/`,
         ],
       },
       refreshTokenValidity: cdk.Duration.days(30),
@@ -249,11 +249,10 @@ export class VinventureLambdaStack extends cdk.Stack {
     const dbHost = database.clusterEndpoint.hostname;
     const dbPort = database.clusterEndpoint.port.toString();
 
-    // Environment-specific CORS origins
-    const corsOrigins = [
-      'http://localhost:3000',
-      `https://${distribution.domainName}`,
-    ];
+    // CORS origins -- CloudFront domain added post-deploy to avoid circular dependency
+    const corsOrigins = isProduction
+      ? ['https://vinventure.com', 'https://www.vinventure.com']
+      : ['http://localhost:3000', 'https://*.cloudfront.net'];
 
     // Lambda environment variables
     const lambdaEnvironment = {


### PR DESCRIPTION
## Summary

Fixes CloudFormation circular dependency that caused the production deploy to fail in CI.

The dependency chain was:
```
CloudFront distribution -> API Gateway -> Lambda -> UserPoolClient ID (env) -> Distribution domain (callback URL)
```

**Fix:** Remove `distribution.domainName` from Cognito callback URLs and CORS origins. Use custom domain for production CORS (`vinventure.com`), wildcard for dev/staging (`*.cloudfront.net`). Cognito callback URL for CloudFront should be added post-deploy or when a custom domain is configured.

## Test plan
- [x] CDK TypeScript compiles without errors
- [ ] `cdk synth` produces valid CloudFormation without circular reference
- [ ] CDK deploy succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)