### PR TITLE
fix: build frontend in deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,17 +59,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Download Frontend Build
-        uses: actions/download-artifact@v4
-        with:
-          name: frontend-build
-          path: apps/web/out
-        continue-on-error: true
-
-      - name: Build Frontend (if no artifact)
-        if: steps.download-frontend.outcome == 'failure'
-        run: pnpm run build:static
-        working-directory: .
+      - name: Build Frontend
+        run: |
+          cd ${{ github.workspace }}
+          pnpm run build:static
 
       - name: CDK Bootstrap (if needed)
         run: |


### PR DESCRIPTION
## Summary

Fixes `Cannot find asset at apps/web/out` error during CDK deploy.

The deploy job tried to download a frontend build artifact from the validate workflow, but artifacts from reusable workflow callers aren't reliably accessible in downstream jobs. Replaced with a direct `pnpm run build:static` in the deploy job.

## Test plan
- [ ] Deploy workflow builds frontend and CDK deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)