### PR TITLE
chore(deps): upgrade constructs and @types/node

### DIFF
--- a/apps/infrastructure/package.json
+++ b/apps/infrastructure/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.257.0",
-    "constructs": "^10.4.2",
+    "constructs": "^10.6.0",
     "@aws-solutions-constructs/aws-cloudfront-s3": "^2.85.6",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@types/node": "18.16.9",
+    "@types/node": "^25.9.1",
     "typescript": "~5.8.2",
     "ts-node": "10.9.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,35 +36,35 @@ importers:
         version: 1.60.0
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
     devDependencies:
       '@nx/devkit':
         specifier: 22.7.5
         version: 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/eslint':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+        version: 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/eslint-plugin':
         specifier: 22.7.5
         version: 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@2.7.0))(typescript@5.8.3))(eslint-config-prettier@10.1.5(eslint@9.30.1(jiti@2.7.0)))(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)
       '@nx/jest':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3)
+        version: 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3)
       '@nx/js':
         specifier: 22.7.5
         version: 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/next':
         specifier: 22.7.5
-        version: 22.7.5(ab3eadaff5589d687e979e9818ab1cc3)
+        version: 22.7.5(6ae04d57a4535f2ea5a9914bd2ba1f5d)
       '@nx/playwright':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+        version: 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/vite':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
+        version: 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
       '@nx/web':
         specifier: 22.7.5
-        version: 22.7.5(8f2c620d19014dc5651c862fe1fe1b5f)
+        version: 22.7.5(369b8f23a2872f9779885413f717cbaf)
       '@nx/workspace':
         specifier: 22.7.5
         version: 22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))
@@ -91,23 +91,23 @@ importers:
     dependencies:
       '@aws-solutions-constructs/aws-cloudfront-s3':
         specifier: ^2.85.6
-        version: 2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.257.0
-        version: 2.257.0(constructs@10.4.2)
+        version: 2.257.0(constructs@10.6.0)
       constructs:
-        specifier: ^10.4.2
-        version: 10.4.2
+        specifier: ^10.6.0
+        version: 10.6.0
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
     devDependencies:
       '@types/node':
-        specifier: 18.16.9
-        version: 18.16.9
+        specifier: ^25.9.1
+        version: 25.9.1
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@18.16.9)(typescript@5.8.3)
+        version: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
@@ -3630,6 +3630,9 @@ packages:
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -4671,8 +4674,8 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  constructs@10.4.2:
-    resolution: {integrity: sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==}
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -8967,6 +8970,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
@@ -10011,23 +10017,23 @@ snapshots:
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
-  '@aws-solutions-constructs/aws-cloudfront-s3@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/aws-cloudfront-s3@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-solutions-constructs/core': 2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)
-      '@aws-solutions-constructs/resources': 2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.257.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-solutions-constructs/core': 2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)
+      '@aws-solutions-constructs/resources': 2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.257.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.257.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.257.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/resources@2.85.6(@aws-solutions-constructs/core@2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-solutions-constructs/core': 2.85.6(aws-cdk-lib@2.257.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.257.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-solutions-constructs/core': 2.85.6(aws-cdk-lib@2.257.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.257.0(constructs@10.6.0)
+      constructs: 10.6.0
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
@@ -12103,7 +12109,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))':
+  '@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
@@ -12112,7 +12118,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3)
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3)
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -12123,7 +12129,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3)':
+  '@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
       '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
@@ -12131,7 +12137,7 @@ snapshots:
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.8.3)
       identity-obj-proxy: 3.0.0
-      jest-config: 30.4.2(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))
+      jest-config: 30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))
       jest-resolve: 30.4.1
       jest-util: 30.4.1
       minimatch: 10.2.5
@@ -12191,14 +12197,14 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.7.5(559be871876b4a0a65f071b432492707)':
+  '@nx/module-federation@22.7.5(4bb248f036f94208ffa48adb0e2dde70)':
     dependencies:
       '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.8.3)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(postcss@8.4.38))
       '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.8.3)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(postcss@8.4.38))
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/web': 22.7.5(8f2c620d19014dc5651c862fe1fe1b5f)
+      '@nx/web': 22.7.5(369b8f23a2872f9779885413f717cbaf)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       express: 4.21.2
       http-proxy-middleware: 3.0.5
@@ -12238,14 +12244,14 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/next@22.7.5(ab3eadaff5589d687e979e9818ab1cc3)':
+  '@nx/next@22.7.5(6ae04d57a4535f2ea5a9914bd2ba1f5d)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.0)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/react': 22.7.5(20243aaacf53dd095fd5686a6e08b228)
-      '@nx/web': 22.7.5(8f2c620d19014dc5651c862fe1fe1b5f)
+      '@nx/react': 22.7.5(f4c7c15fae0e7c8dd4e32240aeb384d3)
+      '@nx/web': 22.7.5(369b8f23a2872f9779885413f717cbaf)
       '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
@@ -12327,10 +12333,10 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.7.5':
     optional: true
 
-  '@nx/playwright@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))':
+  '@nx/playwright@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       minimatch: 10.2.5
       tslib: 2.8.1
@@ -12348,14 +12354,14 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/react@22.7.5(20243aaacf53dd095fd5686a6e08b228)':
+  '@nx/react@22.7.5(f4c7c15fae0e7c8dd4e32240aeb384d3)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/module-federation': 22.7.5(559be871876b4a0a65f071b432492707)
+      '@nx/module-federation': 22.7.5(4bb248f036f94208ffa48adb0e2dde70)
       '@nx/rollup': 22.7.5(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/babel__core@7.20.5)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)
-      '@nx/web': 22.7.5(8f2c620d19014dc5651c862fe1fe1b5f)
+      '@nx/web': 22.7.5(369b8f23a2872f9779885413f717cbaf)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
       express: 4.21.2
@@ -12365,7 +12371,7 @@ snapshots:
       semver: 7.8.1
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
+      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -12434,11 +12440,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))':
+  '@nx/vite@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/vitest': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
+      '@nx/vitest': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.8.3)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -12446,8 +12452,8 @@ snapshots:
       semver: 7.8.1
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
-      vitest: 4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
+      vitest: 4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -12459,7 +12465,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))':
+  '@nx/vitest@22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
@@ -12467,9 +12473,9 @@ snapshots:
       semver: 7.8.1
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      vite: 8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
-      vitest: 4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
+      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
+      vitest: 4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12480,7 +12486,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.5(8f2c620d19014dc5651c862fe1fe1b5f)':
+  '@nx/web@22.7.5(369b8f23a2872f9779885413f717cbaf)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
@@ -12489,10 +12495,10 @@ snapshots:
       picocolors: 1.1.1
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3)
-      '@nx/playwright': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
+      '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3)
+      '@nx/playwright': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@playwright/test@1.60.0)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))
+      '@nx/vite': 22.7.5(@babel/traverse@7.29.7)(@nx/eslint@22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3))(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@9.30.1(jiti@2.7.0))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23))))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))
       '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc/core@1.5.29(@swc/helpers@0.5.23))(nx@22.7.5(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -13726,6 +13732,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/parse-json@4.0.2': {}
 
   '@types/passport-jwt@4.0.1':
@@ -14016,10 +14026,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -14038,13 +14048,13 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@18.16.9)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14453,12 +14463,12 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-cdk-lib@2.257.0(constructs@10.4.2):
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.273
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
       '@aws-cdk/cloud-assembly-schema': 53.28.0
-      constructs: 10.4.2
+      constructs: 10.6.0
 
   aws-jwt-verify@4.0.1: {}
 
@@ -14990,7 +15000,7 @@ snapshots:
 
   consola@3.4.2: {}
 
-  constructs@10.4.2: {}
+  constructs@10.6.0: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -17034,7 +17044,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.4.2(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3)):
+  jest-config@30.4.2(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.28.0
       '@jest/get-type': 30.1.0
@@ -17060,8 +17070,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.11
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3)
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17110,7 +17120,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 18.16.9
+      '@types/node': 20.19.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -20046,6 +20056,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.5.29(@swc/helpers@0.5.23)
 
+  ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.29(@swc/helpers@0.5.23)
+
   ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@20.19.11)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -20065,6 +20095,27 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.5.29(@swc/helpers@0.5.23)
+
+  ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@25.9.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.5.29(@swc/helpers@0.5.23)
+    optional: true
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -20191,6 +20242,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.24.6: {}
+
   undici@7.24.7: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -20304,7 +20357,7 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -20312,7 +20365,7 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 20.19.11
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.1.3
@@ -20352,10 +20405,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@20.19.11)(jsdom@22.1.0)(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.1)(jsdom@22.1.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -20372,10 +20425,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@20.19.11)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.2)(sass@1.89.2)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.11
+      '@types/node': 25.9.1
       jsdom: 22.1.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

- Upgrade `constructs` from 10.4.2 → 10.6.0 (CDK dependency)
- Upgrade `@types/node` from 18.16.9 → 25.9.1
- Closed #106 (TypeScript 6.0.3) — Nx-managed dep per Dependabot policy

Closes #107, closes #105.

## Test plan

- [x] `tsc --noEmit` passes for infrastructure project
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)